### PR TITLE
docs: Add Arch Linux AUR package and installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Under the hood: four fused scoring metrics (block SSIM, Pearson correlation, mea
 | macOS (26+)                | arm64        | `Encounty-arm64.dmg`          |
 | Windows 11 (26H1+)         | x64 + arm64  | `Encounty-Setup.exe`          |
 
+### Arch Linux
+
+If you are using Arch Linux, you can install the application using your favorite AUR helper (e.g. [yay](https://github.com/Jguer/yay)):
+
+```bash
+yay -S encounty-bin
+```
+
 ## How It Works
 
 1. Capture your game screen, window, or camera feed (one source per hunt)


### PR DESCRIPTION
Hi there! 

First of all, thank you so much for this app. It is the first auto shiny counter I found that works reliably on modern Wayland-based Linux systems for me. I've been using it a lot lately and have already caught a Faraway Island Mew in Emerald, as well as Deoxys, Ho-Oh and Mewtwo in FireRed! 

As an Arch Linux user, I'm not a huge fan of dealing with raw AppImages because they don't natively come with standard desktop launchers, and keeping them updated manually can be a bit tedious. To make life easier for myself and other Arch users, I created an Arch User Repository (AUR) package for it: https://aur.archlinux.org/packages/encounty-bin

I've opened this PR to add a small section to the `README.md` letting Arch users know they can install it via an AUR helper (which acts like a package manager for community-driven scripts). The AUR repo allows all users on Arch and Arch-based distros like CachyOS to install encounty with one simple command like this:

```bash
yay -S encounty-bin
```
I completely understand if you prefer not to merge this since it points to a third-party downstream package, but I thought it would be a useful addition for the community!

### What the AUR package actually does under the hood:
For transparency, the `PKGBUILD` script automates the full installation securely using native package management workflows:
1. **Downloads and Verifies the AppImage**: Downloads the precompiled AppImage binary directly from your repository's official GitHub releases page and automatically verifies its integrity using a SHA-256 checksum mismatch check.
2. **Deploys the Binary**: Places the verified AppImage into a isolated directory at `/opt/encounty-bin/encounty.AppImage` and sets executable permissions (`755`).
3. **Exposes System Binary Paths**: Ensures the standard `/usr/bin/` system directory structure exists inside the package root.
4. **Creates a Symbolic Link**: Creates a system symlink pointing from `/usr/bin/encounty` back to the AppImage in `/opt`, letting users launch the app seamlessly via terminal commands.
5. **Downloads the Application Icon**: Pulls the official image asset (`backend/winres/icon.png`) directly from the main repository branch and places it into the system-wide high-color icons directory (`/usr/share/icons/hicolor/256x256/apps/encounty.png`) so desktop environments can find it.
6. **Integrates Application Launchers**: Installs a localized `.desktop` file configuration into `/usr/share/applications/encounty.desktop`, allowing the app to appear natively in standard desktop environment search menus (like GNOME, KDE, or Rofi).

If you want to review the exact script, you can look up the install script directly at the official repository here: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=encounty-bin. I tried to write clear code comments directly inside the `PKGBUILD` mapping out each of these steps cleanly so it is easy for you to review and verify what it does!

Thank you for your time and for making such a great tool!
