### PR TITLE
fix: make the path-containment check analyzable, refresh deps, document AUR

### DIFF
--- a/backend/internal/pathsafe/pathsafe.go
+++ b/backend/internal/pathsafe/pathsafe.go
@@ -11,12 +11,16 @@ import (
 
 // Join cleans base and appends elems, returning an error if the resulting path
 // would escape base (e.g. via ".." components). The returned path is always
-// filepath.Clean-ed and guaranteed to be base itself or a descendant of it.
+// filepath.Clean-ed and guaranteed to be a strict descendant of base.
+//
+// The containment check is a prefix comparison against base plus a trailing
+// separator rather than a filepath.Rel round trip: the separator rules out
+// sibling directories that merely share a name prefix, and static analysis
+// recognizes the shape as a path-traversal barrier.
 func Join(base string, elems ...string) (string, error) {
-	cleanBase := filepath.Clean(base)
-	joined := filepath.Join(append([]string{cleanBase}, elems...)...)
-	rel, err := filepath.Rel(cleanBase, joined)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	prefix := filepath.Clean(base) + string(filepath.Separator)
+	joined := filepath.Join(append([]string{prefix}, elems...)...)
+	if !strings.HasPrefix(joined, prefix) {
 		return "", fmt.Errorf("path %q escapes base directory %q", filepath.Join(elems...), base)
 	}
 	return joined, nil

--- a/backend/internal/pathsafe/pathsafe_test.go
+++ b/backend/internal/pathsafe/pathsafe_test.go
@@ -23,10 +23,21 @@ func TestJoinRejectsTraversal(t *testing.T) {
 		"templates/../../../etc/passwd",
 		"..",
 		filepath.FromSlash("templates/../.."),
+		// Sibling directory sharing the base name as a string prefix.
+		filepath.FromSlash("../encounty-evil/state.json"),
 	}
 	for _, c := range cases {
 		if _, err := Join(base, c); err == nil {
 			t.Errorf("Join(base, %q) = nil error, want escape error", c)
+		}
+	}
+}
+
+func TestJoinRejectsBaseItself(t *testing.T) {
+	base := filepath.FromSlash("/data/encounty")
+	for _, elems := range [][]string{nil, {""}, {"."}, {"templates", ".."}} {
+		if got, err := Join(base, elems...); err == nil {
+			t.Errorf("Join(base, %q) = %q, want error: base itself is not a valid target", elems, got)
 		}
 	}
 }

--- a/electron/yarn.lock
+++ b/electron/yarn.lock
@@ -503,24 +503,24 @@ boolean@^3.0.1:
   integrity sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1, brace-expansion@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.5:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
   dependencies:
     balanced-match "^4.0.2"
 

--- a/site/index.html
+++ b/site/index.html
@@ -245,8 +245,8 @@
             >
           </div>
           <p class="mt-4 text-sm text-text-muted" data-i18n="dl.formats">
-            AppImage (Linux) · installer + portable .exe (Windows 11) · DMG (macOS, Apple
-            Silicon) · free & AGPL-3.0
+            AppImage (Linux, AUR for Arch) · installer + portable .exe (Windows 11) · DMG (macOS,
+            Apple Silicon) · free & AGPL-3.0
           </p>
         </div>
       </section>

--- a/site/src/locales/de.json
+++ b/site/src/locales/de.json
@@ -34,7 +34,7 @@
   "hero.ctaDownload": "Download",
   "hero.ctaChangelog": "Changelog",
 
-  "dl.formats": "AppImage (Linux) · Installer + portable .exe (Windows 11) · DMG (macOS, Apple Silicon) · kostenlos & AGPL-3.0",
+  "dl.formats": "AppImage (Linux, AUR für Arch) · Installer + portable .exe (Windows 11) · DMG (macOS, Apple Silicon) · kostenlos & AGPL-3.0",
 
   "screens.heading": "Screenshots",
   "screens.dashboardAlt": "Encounty-Dashboard mit aktiven Shiny-Hunts, Encounter-Zähler, Timer und Odds",
@@ -227,6 +227,14 @@
   "update.linux.dlBtn": "Encounty für Linux herunterladen",
   "update.linux.dlArm": "AppImage für ARM64",
   "update.linux.dlNoteSuffix": "aktualisiert sich von da an selbst.",
+
+  "update.linux.aur.title": "Arch Linux und Arch-basierte Distributionen",
+  "update.linux.aur.introBefore": "Spar dir den manuellen Download und installiere das",
+  "update.linux.aur.pkgLink": "Paket encounty-bin aus dem AUR",
+  "update.linux.aur.introAfter": ", zum Beispiel mit einem AUR-Helper wie yay oder paru:",
+  "update.linux.aur.copyAria": "AUR-Installationsbefehl in die Zwischenablage kopieren",
+  "update.linux.aur.updateNote": "Das Paket bringt alles mit, was Encounty braucht, inklusive fuse2. Updates kommen dann über deinen Paketmanager, der eingebaute Updater hält sich raus.",
+
   "update.linux.step1.title": "AppImage herunterladen",
   "update.linux.step1.desc": "Nutze den Button oben für deine Architektur (x64 für die meisten PCs).",
   "update.linux.step2.title": "Ausführbar machen",

--- a/site/src/locales/en.json
+++ b/site/src/locales/en.json
@@ -34,7 +34,7 @@
   "hero.ctaDownload": "Download",
   "hero.ctaChangelog": "Changelog",
 
-  "dl.formats": "AppImage (Linux) · installer + portable .exe (Windows 11) · DMG (macOS, Apple Silicon) · free & AGPL-3.0",
+  "dl.formats": "AppImage (Linux, AUR for Arch) · installer + portable .exe (Windows 11) · DMG (macOS, Apple Silicon) · free & AGPL-3.0",
 
   "screens.heading": "Screenshots",
   "screens.dashboardAlt": "Encounty dashboard showing active shiny hunts with encounter counter, timer and odds",
@@ -227,6 +227,14 @@
   "update.linux.dlBtn": "Download Encounty for Linux",
   "update.linux.dlArm": "AppImage for ARM64",
   "update.linux.dlNoteSuffix": "updates itself from then on.",
+
+  "update.linux.aur.title": "Arch Linux and Arch-based distributions",
+  "update.linux.aur.introBefore": "Skip the manual download and install the",
+  "update.linux.aur.pkgLink": "encounty-bin package from the AUR",
+  "update.linux.aur.introAfter": ", for example with an AUR helper such as yay or paru:",
+  "update.linux.aur.copyAria": "Copy AUR install command to clipboard",
+  "update.linux.aur.updateNote": "The package pulls in everything Encounty needs, including fuse2. Updates then come from your package manager, so the built-in updater stays out of the way.",
+
   "update.linux.step1.title": "Download the AppImage",
   "update.linux.step1.desc": "Use the button above for your architecture (x64 for most PCs).",
   "update.linux.step2.title": "Make it executable",

--- a/site/src/locales/es.json
+++ b/site/src/locales/es.json
@@ -34,7 +34,7 @@
   "hero.ctaDownload": "Descargar",
   "hero.ctaChangelog": "Cambios",
 
-  "dl.formats": "AppImage (Linux) · instalador + portable .exe (Windows 11) · DMG (macOS, Apple Silicon) · gratis y AGPL-3.0",
+  "dl.formats": "AppImage (Linux, AUR para Arch) · instalador + portable .exe (Windows 11) · DMG (macOS, Apple Silicon) · gratis y AGPL-3.0",
 
   "screens.heading": "Capturas de pantalla",
   "screens.dashboardAlt": "Panel de Encounty mostrando cazas de shinies activas con contador de encuentros, temporizador y probabilidades",
@@ -227,6 +227,14 @@
   "update.linux.dlBtn": "Descargar Encounty para Linux",
   "update.linux.dlArm": "AppImage para ARM64",
   "update.linux.dlNoteSuffix": "se actualiza sola a partir de entonces.",
+
+  "update.linux.aur.title": "Arch Linux y distribuciones basadas en Arch",
+  "update.linux.aur.introBefore": "Evita la descarga manual e instala el",
+  "update.linux.aur.pkgLink": "paquete encounty-bin del AUR",
+  "update.linux.aur.introAfter": ", por ejemplo con un asistente de AUR como yay o paru:",
+  "update.linux.aur.copyAria": "Copiar el comando de instalación del AUR al portapapeles",
+  "update.linux.aur.updateNote": "El paquete incluye todo lo que Encounty necesita, incluido fuse2. Las actualizaciones llegan entonces desde tu gestor de paquetes, así que el actualizador integrado se mantiene al margen.",
+
   "update.linux.step1.title": "Descarga la AppImage",
   "update.linux.step1.desc": "Usa el botón de arriba para tu arquitectura (x64 en la mayoría de los PCs).",
   "update.linux.step2.title": "Hazla ejecutable",

--- a/site/src/locales/fr.json
+++ b/site/src/locales/fr.json
@@ -34,7 +34,7 @@
   "hero.ctaDownload": "Télécharger",
   "hero.ctaChangelog": "Nouveautés",
 
-  "dl.formats": "AppImage (Linux) · installateur + portable .exe (Windows 11) · DMG (macOS, Apple Silicon) · gratuit et AGPL-3.0",
+  "dl.formats": "AppImage (Linux, AUR pour Arch) · installateur + portable .exe (Windows 11) · DMG (macOS, Apple Silicon) · gratuit et AGPL-3.0",
 
   "screens.heading": "Captures d'écran",
   "screens.dashboardAlt": "Tableau de bord d'Encounty affichant des chasses aux shinies actives avec compteur de rencontres, minuteur et probabilités",
@@ -227,6 +227,14 @@
   "update.linux.dlBtn": "Télécharger Encounty pour Linux",
   "update.linux.dlArm": "AppImage pour ARM64",
   "update.linux.dlNoteSuffix": "se met à jour toute seule ensuite.",
+
+  "update.linux.aur.title": "Arch Linux et distributions dérivées d'Arch",
+  "update.linux.aur.introBefore": "Évite le téléchargement manuel et installe le",
+  "update.linux.aur.pkgLink": "paquet encounty-bin depuis l'AUR",
+  "update.linux.aur.introAfter": ", par exemple avec un assistant AUR comme yay ou paru :",
+  "update.linux.aur.copyAria": "Copier la commande d'installation AUR dans le presse-papiers",
+  "update.linux.aur.updateNote": "Le paquet installe tout ce dont Encounty a besoin, y compris fuse2. Les mises à jour passent alors par ton gestionnaire de paquets, et le programme de mise à jour intégré reste en retrait.",
+
   "update.linux.step1.title": "Téléchargez l'AppImage",
   "update.linux.step1.desc": "Utilisez le bouton ci-dessus pour votre architecture (x64 pour la plupart des PC).",
   "update.linux.step2.title": "Rendez-la exécutable",

--- a/site/src/locales/ja.json
+++ b/site/src/locales/ja.json
@@ -34,7 +34,7 @@
   "hero.ctaDownload": "ダウンロード",
   "hero.ctaChangelog": "変更履歴",
 
-  "dl.formats": "AppImage (Linux) · インストーラー + ポータブル .exe (Windows 11) · DMG (macOS、Apple Silicon) · 無料 & AGPL-3.0",
+  "dl.formats": "AppImage (Linux、Arch 向け AUR) · インストーラー + ポータブル .exe (Windows 11) · DMG (macOS、Apple Silicon) · 無料 & AGPL-3.0",
 
   "screens.heading": "スクリーンショット",
   "screens.dashboardAlt": "遭遇カウンター、タイマー、確率とともに進行中の色違い厳選を表示する Encounty のダッシュボード",
@@ -227,6 +227,14 @@
   "update.linux.dlBtn": "Linux 版 Encounty をダウンロード",
   "update.linux.dlArm": "ARM64 向け AppImage",
   "update.linux.dlNoteSuffix": "以降は自動で更新されます。",
+
+  "update.linux.aur.title": "Arch Linux および Arch 系ディストリビューション",
+  "update.linux.aur.introBefore": "手動ダウンロードは不要です。",
+  "update.linux.aur.pkgLink": "AUR の encounty-bin パッケージ",
+  "update.linux.aur.introAfter": "を、yay や paru などの AUR ヘルパーでインストールしてください:",
+  "update.linux.aur.copyAria": "AUR のインストールコマンドをクリップボードにコピー",
+  "update.linux.aur.updateNote": "このパッケージは fuse2 を含め、Encounty に必要なものをすべて導入します。更新はパッケージマネージャー経由になるため、内蔵アップデーターは動作しません。",
+
   "update.linux.step1.title": "AppImage をダウンロード",
   "update.linux.step1.desc": "お使いのアーキテクチャに合わせて上のボタンを使います (ほとんどの PC は x64 です)。",
   "update.linux.step2.title": "実行可能にする",

--- a/site/update.html
+++ b/site/update.html
@@ -551,6 +551,43 @@
                 </p>
               </div>
 
+              <div class="mt-8 border border-border-subtle bg-bg-secondary p-5">
+                <h4 class="font-semibold text-text-primary" data-i18n="update.linux.aur.title">
+                  Arch Linux and Arch-based distributions
+                </h4>
+                <p class="mt-2 text-sm text-text-secondary">
+                  <span data-i18n="update.linux.aur.introBefore"
+                    >Skip the manual download and install the</span
+                  >
+                  <a
+                    href="https://aur.archlinux.org/packages/encounty-bin"
+                    class="underline hover:text-text-primary"
+                    rel="noopener"
+                    data-i18n="update.linux.aur.pkgLink"
+                    >encounty-bin package from the AUR</a
+                  ><span data-i18n="update.linux.aur.introAfter"
+                    >, for example with an AUR helper such as yay or paru:</span
+                  >
+                </p>
+                <div class="copy-block mt-3">
+                  <code>yay -S encounty-bin</code>
+                  <button
+                    type="button"
+                    class="copy-block__btn"
+                    data-copy="yay -S encounty-bin"
+                    aria-label="Copy AUR install command to clipboard"
+                    data-i18n="copy.label"
+                    data-i18n-attr="aria-label:update.linux.aur.copyAria"
+                  >
+                    Copy
+                  </button>
+                </div>
+                <p class="mt-3 text-sm text-text-muted" data-i18n="update.linux.aur.updateNote">
+                  The package pulls in everything Encounty needs, including fuse2. Updates then come
+                  from your package manager, so the built-in updater stays out of the way.
+                </p>
+              </div>
+
               <ol class="mt-8 space-y-6">
                 <li class="flex gap-4">
                   <span aria-hidden="true" class="t-step-n shrink-0">1</span>


### PR DESCRIPTION
Three unrelated but small changes:

- `pathsafe.Join` now checks containment with a prefix comparison against base plus a trailing separator instead of a `filepath.Rel` round trip. The old check inspected the relative result, which static analysis could not recognize as a traversal barrier, so all 14 open code-scanning alerts pointed at sinks that were already contained. Behaviour is unchanged apart from rejecting base itself, which no caller relied on.
- `brace-expansion` refreshed in the electron lockfile (1.1.18 / 2.1.4 / 5.0.9), all inside the existing caret ranges.
- The download page now shows the `encounty-bin` AUR package for Arch users, with the install command and a note that updates come from the package manager. Strings added to all five locales.